### PR TITLE
Fixed the version at 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "hyphenate-style-name": "^1.0.1"
+    "hyphenate-style-name": "1.0.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Hi! I just happened to find the issue that unitless-css-property has dependency version issue for the hyphenate-name-style lib.

hyphenate-name-style released 1.0.3 and it changed the module export from CommonJS style to ES6. But it causes the instantiation timing issue. See more detail here:

https://medium.com/the-node-js-collection/an-update-on-es6-modules-in-node-js-42c958b890c

See the change here:

https://github.com/rexxars/hyphenate-style-name/commit/47eeec55fc9d0d2601bcc1d9837b2765fabfa50c#diff-168726dbe96b3ce427e7fedce31bb0bc

I think this change is breakable change, so hyphen-name-style should change the minor version rather than patch version number.

In this change, I fixed the version at 1.0.2 and I believe it shouldn't be harmful your library.
